### PR TITLE
Add Keywords to the desktop file.

### DIFF
--- a/fotoprint.desktop
+++ b/fotoprint.desktop
@@ -14,3 +14,4 @@ Terminal=false
 Type=Application
 Categories=Graphics;Photography;GNOME;GTK;
 MimeType=image/tiff;image/jpeg;image/png;
+Keywords=image;printing;poster;split;arrange;icc;


### PR DESCRIPTION
The Keywords field in photoprint.desktop file is missing.
This prevents searching through entries in Linux desktop environment, so it's recommended to add this field for Debian package.

Feel free to update the initial keyword list if some keywords are missing.

Thanks,