### PR TITLE
Escape minus signs in man page.

### DIFF
--- a/photoprint.1
+++ b/photoprint.1
@@ -19,14 +19,14 @@
 photoprint \- a utility to print images using Gutenprint.
 .SH SYNOPSIS
 .B photoprint
-[-h]
-[--help]
-[-v]
-[--version]
-[-p \fI<presetfile>\fP]
-[--preset \fI<presetfile>\fP]
-[-b]
-[--bbatch]
+[\-h]
+[\-\-help]
+[\-v]
+[\-\-version]
+[\-p \fI<presetfile>\fP]
+[\-\-preset \fI<presetfile>\fP]
+[\-b]
+[\-\-bbatch]
 [images ...]
 .SH DESCRIPTION
 .B photoprint


### PR DESCRIPTION
Some minus signs are not escaped in the man page.
According to the [groff manual](https://man7.org/linux/man-pages/man7/groff.7.html#Escape_Sequences), the minus sign has to be escaped to be correctly rendered with the font.

Thanks,